### PR TITLE
Fixed stepMixin typo

### DIFF
--- a/src/mixins/stepMixin.js
+++ b/src/mixins/stepMixin.js
@@ -16,7 +16,7 @@ export const stepMixin = {
     isMobile () {
       return this.$vuetify.breakpoint.xs
     },
-    ...mapState(['ordrr, validations']),
+    ...mapState(['order', 'validations']),
     ...mapFields(['current_step'])
   },
   methods: {


### PR DESCRIPTION
Hi @fconforti, we found a small typo while debugging some issues. 
The typo just prevents Google Tag Manager submissions from working properly, so no big deal.
Our issues were caused by a misconfiguration on our end.